### PR TITLE
create sg for github meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_github"></a> [github](#provider\_github) | 5.1.0 |
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -15,6 +16,8 @@
 | Name | Type |
 |------|------|
 | [aws_security_group.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [github_ip_ranges.action](https://registry.terraform.io/providers/integrations/github/5.1.0/docs/data-sources/ip_ranges) | data source |
 ## Outputs
 
 | Name | Description |

--- a/README.md
+++ b/README.md
@@ -2,14 +2,22 @@
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The vpc\_id to add the security group into | `string` | `""` | no |
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_security_group.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,10 @@
+resource "aws_security_group" "github" {
+  name        = "github_meta_actions_ingress"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "github-meta-actions"
+  }
+}
+

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,30 @@
+data "github_ip_ranges" "action" {}
+
 resource "aws_security_group" "github" {
   name        = "github_meta_actions_ingress"
   description = "Allow TLS inbound traffic"
   vpc_id      = var.vpc_id
 
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
   tags = {
     Name = "github-meta-actions"
   }
+}
+
+resource "aws_security_group_rule" "github" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = data.github_ip_ranges.action.actions_ipv4
+  ipv6_cidr_blocks  = data.github_ip_ranges.action.actions_ipv6
+  security_group_id = aws_security_group.github.id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "security_group_id" {
+  value = aws_security_group.github.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,4 @@
+variable "vpc_id" {
+  description = "The vpc_id to add the security group into"
+  default     = ""
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    github = {
+      source = "integrations/github"
+      version = "5.1.0"
+    }
+  }
+}
+
+provider "github" {}


### PR DESCRIPTION
Closes #1 

Currently, I just create the SG for github meta. When I tried to create ingress rules with actions CIDR blocks, I got security group rules exceeded error. There are a lot of ip address for actions block https://api.github.com/meta